### PR TITLE
Add new playbook to setup couchbase 7 on RedHat 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,6 +112,13 @@ couchbase_server_centos_ce_url: http://packages.couchbase.com/releases/{{ couchb
 couchbase_server_centos_ce_sha256: 73f048e49617095e6a0cb9a82f74578d48b1054e8142fb712eab71395d7b9ce0
 
 #
+#  RedHat 8
+couchbase_server_RedHat_8_community_version: 7.0.2
+couchbase_server_RedHat_8_community_package: couchbase-server-community-{{ couchbase_server_RedHat_8_community_version }}-centos8.x86_64.rpm
+couchbase_server_RedHat_8_community_url: http://packages.couchbase.com/releases/{{ couchbase_server_RedHat_8_community_version }}/{{ couchbase_server_RedHat_8_community_package }}
+couchbase_server_RedHat_8_community_sha256: a26c2cd8d2b0dcea35dab82b09bdaa9d7abf7d7f5c28b026e8302f2c8bdc0a15
+
+#
 # Debian 7
 #
 couchbase_server_debian_ee_version: 4.0.0

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -1,0 +1,26 @@
+---
+- set_fact:
+    couchbase_server_version: "{{ lookup('vars', 'couchbase_server_' + ansible_distribution+ '_' +  ansible_distribution_major_version + '_'+ couchbase_server_edition + '_version') }}"
+    couchbase_server_package: "{{ lookup('vars', 'couchbase_server_' + ansible_distribution+ '_' +  ansible_distribution_major_version + '_'+ couchbase_server_edition + '_package') }}"
+    couchbase_server_url: "{{ lookup('vars', 'couchbase_server_' + ansible_distribution+ '_' +  ansible_distribution_major_version + '_'+ couchbase_server_edition + '_url') }}"
+    couchbase_server_sha256: "{{ lookup('vars', 'couchbase_server_' + ansible_distribution+ '_' +  ansible_distribution_major_version + '_'+ couchbase_server_edition + '_sha256') }}"
+
+- name: Copy package
+  copy: "src={{ couchbase_server_package }} dest=/tmp/{{ couchbase_server_package }}"
+  when: couchbase_server_local_package == true
+  tags: installation
+
+- name: Download package
+  get_url: "url={{ couchbase_server_url }} dest=/tmp/{{ couchbase_server_package }} sha256sum={{ couchbase_server_sha256 }} timeout=240"
+  when: couchbase_server_local_package != true
+  tags: installation
+
+- name: Install package
+  become: True
+  yum: "name=/tmp/{{ couchbase_server_package }} state=present"
+  tags: installation
+
+- name: Package file cleanup
+  become: True
+  file: "dest=/tmp/{{ couchbase_server_package }} state=absent"
+  tags: installation


### PR DESCRIPTION
this pr is only for couchbase 7 on RedHat 8. but it's easy to support other OS. 